### PR TITLE
Use REDIS_URL env for redis

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-worker: python cli.py --broker=$REDIS_BROKER
+worker: python cli.py --broker=$REDIS_URL


### PR DESCRIPTION
Deprecate REDIS_BROKER, and Use REDIS_URL which is the env variable provided by heroku